### PR TITLE
Read wp_version direct from version.php; core update-db.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,5 +13,8 @@
             "wp-cli-load.php"
         ]
     },
-    "require": {}
+    "require": {},
+	"require-dev": {
+		"behat/behat": "2.5.*"
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,5 @@
             "wp-cli-load.php"
         ]
     },
-    "require": {},
-	"require-dev": {
-		"behat/behat": "2.5.*"
-	}
+    "require": {}
 }

--- a/features/core-safe-update.feature
+++ b/features/core-safe-update.feature
@@ -3,6 +3,7 @@ Feature: Safely update WordPress core
   Background:
     Given a WP install
     And I run `wp core download --force --version=4.6`
+    And I run `wp core update-db`
     And I run `wp theme activate twentysixteen`
     And I run `wp option update home 'http://localhost:8080'`
     And I run `wp option update siteurl 'http://localhost:8080'`
@@ -117,7 +118,8 @@ Feature: Safely update WordPress core
       """
       <?php
       if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
-        if ( version_compare( $GLOBALS['wp_version'], '4.8', '>=' ) ) {
+        $_wp_version = preg_replace( '/^.*\$wp_version *= *\'([^\']+)\';.*$/s', '\\1', file_get_contents( ABSPATH . WPINC . '/version.php' ) );
+        if ( version_compare( $_wp_version, '4.8', '>=' ) ) {
           status_header( 500 );
           exit;
         }
@@ -145,7 +147,8 @@ Feature: Safely update WordPress core
       """
       <?php
       if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
-        if ( version_compare( $GLOBALS['wp_version'], '4.8', '>=' ) ) {
+        $_wp_version = preg_replace( '/^.*\$wp_version *= *\'([^\']+)\';.*$/s', '\\1', file_get_contents( ABSPATH . WPINC . '/version.php' ) );
+        if ( version_compare( $_wp_version, '4.8', '>=' ) ) {
           exit;
         }
       }

--- a/features/fail-http-code.feature
+++ b/features/fail-http-code.feature
@@ -10,9 +10,12 @@ Feature: Verification fails when http code changes
     Given a wp-content/mu-plugins/fail.php file:
       """
       <?php
-      if ( version_compare( $GLOBALS['wp_version'], '4.8', '>=' ) ) {
-        status_header( 500 );
-        exit;
+      if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+        $_wp_version = preg_replace( '/^.*\$wp_version *= *\'([^\']+)\';.*$/s', '\\1', file_get_contents( ABSPATH . WPINC . '/version.php' ) );
+        if ( version_compare( $_wp_version, '4.8', '>=' ) ) {
+          status_header( 500 );
+          exit;
+        }
       }
       """
 
@@ -21,6 +24,7 @@ Feature: Verification fails when http code changes
       """
       Success: WordPress downloaded.
       """
+    And I run `wp core update-db`
 
     When I run `wp core version`
     Then STDOUT should be:

--- a/features/fail-uncaught-fatal.feature
+++ b/features/fail-uncaught-fatal.feature
@@ -3,6 +3,7 @@ Feature: Verification fails when there's an uncaught fatal
   Background:
     Given a WP install
     And I run `wp core download --force --version=4.6`
+    And I run `wp core update-db`
     And I run `wp theme activate twentysixteen`
     And I run `wp option update home 'http://localhost:8080'`
     And I run `wp option update siteurl 'http://localhost:8080'`
@@ -13,8 +14,11 @@ Feature: Verification fails when there's an uncaught fatal
       """
       <?php
       ini_set('display_errors', 1);
-      if ( version_compare( $GLOBALS['wp_version'], '4.8', '>=' ) ) {
-        this_is_an_undefined_function();
+      if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+        $_wp_version = preg_replace( '/^.*\$wp_version *= *\'([^\']+)\';.*$/s', '\\1', file_get_contents( ABSPATH . WPINC . '/version.php' ) );
+        if ( version_compare( $_wp_version, '4.8', '>=' ) ) {
+          this_is_an_undefined_function();
+        }
       }
       """
 


### PR DESCRIPTION
See https://github.com/danielbachhuber/update-verify/issues/15

Ok, X hours later, there seems to be some weird stuff with the `$wp_version` global not getting set when running under the PHP server.

This kludge gets around it by reading `$wp_version` direct from the `wp-includes/version.php` file.

It also does a `wp core update-db` after the `wp core download` as I was getting `delete_all_transients()` function undefined locally.

Also guards more of the `mu-plugin` stuff with `'WP_CLI'` defined checks.