### PR TITLE
Skip extraction of `wp-content` directory when rolling back

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script:
     if [[ "$WP_TRAVISCI" == "behat" ]] ; then
       composer install
       composer global require consolidation/cgr
-      cgr -n wp-cli/wp-cli
+      cgr -n wp-cli/wp-cli:dev-master
       cgr -n "behat/behat=~2.5"
       bash bin/install-package-tests.sh
     fi

--- a/src/CLI.php
+++ b/src/CLI.php
@@ -75,7 +75,7 @@ class CLI {
 						\WP_Upgrader::release_lock( 'core_updater' );
 					}
 					WP_CLI::log( "Rolling WordPress back to version {$current_version}..." );
-					WP_CLI::runcommand( 'core download --force --version=' . $current_version, array(
+					WP_CLI::runcommand( 'core download --skip-content --force --version=' . $current_version, array(
 						'launch' => false,
 					) );
 					WP_CLI::error( $error_message );


### PR DESCRIPTION
Doing so will prevent overwriting any existing themes/plugins

Fixes #18