### PR TITLE
Updated verbiage - Correctly detected closing </body> tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ By default, Update Verify operates in a reporting mode; these heuristics are out
     Updating to version 4.9.1 (en_US)...
     Fetching pre-update site response...
      -> HTTP status code: 200
-     -> Detected closing </body> tag.
+     -> Correctly detected closing </body> tag.
      -> No uncaught fatal error detected.
     Unpacking the update...
     Fetching post-update site response...
      -> HTTP status code: 200
-     -> Detected closing </body> tag.
+     -> Correctly detected closing </body> tag.
      -> No uncaught fatal error detected.
     Cleaning up files...
     No files found that need cleaning up.
@@ -54,7 +54,7 @@ Here's an example of what you might see running `wp core safe-update`:
     Updating to version 4.9.1 (en_US)...
     Fetching pre-update site response...
      -> HTTP status code: 200
-     -> Detected closing </body> tag.
+     -> Correctly detected closing </body> tag.
      -> No uncaught fatal error detected.
     Unpacking the update...
     Fetching post-update site response...
@@ -84,6 +84,9 @@ Installing as a plugin to means Update Verify can also be executed during web-ba
 Both installation methods expose the `wp core safe-update` WP-CLI command, which requires WP-CLI 1.5.0-alpha-d71d228 or newer.
 
 ## Changelog ##
+
+### 0.1.1 (??? ??, 2018) ###
+* Updated 'closing </body> tag' detection message to clarify it's a success.
 
 ### 0.1.0 (??? ??, 2017) ###
 * Initial release.

--- a/features/fail-http-code.feature
+++ b/features/fail-http-code.feature
@@ -37,7 +37,7 @@ Feature: Verification fails when http code changes
       """
       Fetching pre-update site response...
        -> HTTP status code: 200
-       -> Detected closing </body> tag.
+       -> Correctly detected closing </body> tag.
        -> No uncaught fatal error detected.
       """
     And STDOUT should contain:

--- a/features/fail-uncaught-fatal.feature
+++ b/features/fail-uncaught-fatal.feature
@@ -27,7 +27,7 @@ Feature: Verification fails when there's an uncaught fatal
       """
       Fetching pre-update site response...
        -> HTTP status code: 200
-       -> Detected closing </body> tag.
+       -> Correctly detected closing </body> tag.
        -> No uncaught fatal error detected.
       """
     And STDOUT should contain:

--- a/features/pass.feature
+++ b/features/pass.feature
@@ -25,14 +25,14 @@ Feature: Update verification passes
       """
       Fetching pre-update site response...
        -> HTTP status code: 200
-       -> Detected closing </body> tag.
+       -> Correctly detected closing </body> tag.
        -> No uncaught fatal error detected.
       """
     And STDOUT should contain:
       """
       Fetching post-update site response...
        -> HTTP status code: 200
-       -> Detected closing </body> tag.
+       -> Correctly detected closing </body> tag.
        -> No uncaught fatal error detected.
       """
     And STDOUT should contain:

--- a/readme.txt
+++ b/readme.txt
@@ -85,8 +85,5 @@ Both installation methods expose the `wp core safe-update` WP-CLI command, which
 
 == Changelog ==
 
-### 0.1.1 (??? ??, 2018) ###
-* Updated 'closing </body> tag' detection message to clarify it's a success.
-
 = 0.1.0 (??? ??, 2017) =
 * Initial release.

--- a/readme.txt
+++ b/readme.txt
@@ -25,12 +25,12 @@ By default, Update Verify operates in a reporting mode; these heuristics are out
     Updating to version 4.9.1 (en_US)...
     Fetching pre-update site response...
      -> HTTP status code: 200
-     -> Detected closing </body> tag.
+     -> Correctly detected closing </body> tag.
      -> No uncaught fatal error detected.
     Unpacking the update...
     Fetching post-update site response...
      -> HTTP status code: 200
-     -> Detected closing </body> tag.
+     -> Correctly detected closing </body> tag.
      -> No uncaught fatal error detected.
     Cleaning up files...
     No files found that need cleaning up.
@@ -54,7 +54,7 @@ Here's an example of what you might see running `wp core safe-update`:
     Updating to version 4.9.1 (en_US)...
     Fetching pre-update site response...
      -> HTTP status code: 200
-     -> Detected closing </body> tag.
+     -> Correctly detected closing </body> tag.
      -> No uncaught fatal error detected.
     Unpacking the update...
     Fetching post-update site response...
@@ -84,6 +84,9 @@ Installing as a plugin to means Update Verify can also be executed during web-ba
 Both installation methods expose the `wp core safe-update` WP-CLI command, which requires WP-CLI 1.5.0-alpha-d71d228 or newer.
 
 == Changelog ==
+
+### 0.1.1 (??? ??, 2018) ###
+* Updated 'closing </body> tag' detection message to clarify it's a success.
 
 = 0.1.0 (??? ??, 2017) =
 * Initial release.

--- a/src/Observer.php
+++ b/src/Observer.php
@@ -83,7 +83,7 @@ class Observer {
 			self::log_message( ' -> No closing </body> tag detected.' );
 			$site_response['closing_body'] = false;
 		} else {
-			self::log_message( ' -> Detected closing </body> tag.' );
+			self::log_message( ' -> Correctly detected closing </body> tag.' );
 			$site_response['closing_body'] = true;
 		}
 		$stripped_body = strip_tags( $response['body'] );


### PR DESCRIPTION
Updated the verbiage on successful detection of </body> tag to clarify it's not an error.
New Verbiage - `Correctly detected closing </body> tag.`

Note: I wasn't sure if the following feature files should have been updated;
- `features/fail-http-code.feature`
- `features/fail-uncaught-fatal.feature`
- `features/pass.feature`
*If they shouldn't be updated I can remove from the PR.

Thanks
