### PR TITLE
Switch to using the WP-CLI bundle for tests; fix PHPCS issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_script:
     if [[ "$WP_TRAVISCI" == "behat" ]] ; then
       composer install
       composer global require consolidation/cgr
-      cgr -n wp-cli/wp-cli:dev-master
+      cgr -n wp-cli/wp-cli-bundle
       cgr -n "behat/behat=~2.5"
       bash bin/install-package-tests.sh
     fi

--- a/features/pass.feature
+++ b/features/pass.feature
@@ -20,7 +20,7 @@ Feature: Update verification passes
       4.8
       """
 
-    When I run `wp core update`
+    When I run `wp core update --minor`
     Then STDOUT should contain:
       """
       Fetching pre-update site response...

--- a/register-command.php
+++ b/register-command.php
@@ -8,7 +8,9 @@
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 
 	WP_CLI::add_command(
-		'core safe-update', array( 'UpdateVerify\CLI', 'safe_update' ), array(
+		'core safe-update',
+		array( 'UpdateVerify\CLI', 'safe_update' ),
+		array(
 			'before_invoke' => function() {
 				if ( ! version_compare( WP_CLI_VERSION, '1.5.0-alpha', '>=' ) ) {
 					WP_CLI::error( 'Safe update requires WP-CLI 1.5.0-alpha-d71d228 or later' );
@@ -19,9 +21,12 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 
 	// Hack because WP-CLI doesn't like commands registered to 'core' that run on before_wp_load.
 	WP_CLI::add_hook(
-		'find_command_to_run_pre', function() {
+		'find_command_to_run_pre',
+		function() {
 			WP_CLI::add_command(
-				'core safe-update', array( 'UpdateVerify\CLI', 'safe_update' ), array(
+				'core safe-update',
+				array( 'UpdateVerify\CLI', 'safe_update' ),
+				array(
 					'before_invoke' => function() {
 						if ( ! version_compare( WP_CLI_VERSION, '1.5.0-alpha', '>=' ) ) {
 							WP_CLI::error( 'Safe update requires WP-CLI 1.5.0-alpha-d71d228 or later' );

--- a/src/CLI.php
+++ b/src/CLI.php
@@ -82,7 +82,8 @@ class CLI {
 				WP_CLI::error( $is_errored );
 			}
 			WP_CLI::runcommand(
-				'core download --skip-content --force --version=3.7', array(
+				'core download --skip-content --force --version=3.7',
+				array(
 					'launch' => true,
 				)
 			);
@@ -95,7 +96,8 @@ class CLI {
 			if ( $is_errored ) {
 				WP_CLI::log( "Rolling WordPress back to version {$current_version}..." );
 				WP_CLI::runcommand(
-					'core download --skip-content --force --version=' . $current_version, array(
+					'core download --skip-content --force --version=' . $current_version,
+					array(
 						'launch' => true,
 					)
 				);
@@ -111,20 +113,24 @@ class CLI {
 		 * Bail early if any errors are detected with the site.
 		 */
 		WP_CLI::add_wp_hook(
-			'upgrade_verify_upgrader_pre_download', function( $retval, $site_response ) use ( $is_site_response_errored ) {
+			'upgrade_verify_upgrader_pre_download',
+			function( $retval, $site_response ) use ( $is_site_response_errored ) {
 				$is_errored = $is_site_response_errored( $site_response, 'pre' );
 				if ( $is_errored ) {
 					return new \WP_Error( 'upgrade_verify_fail', $is_errored );
 				}
 				return $retval;
-			}, 10, 2
+			},
+			10,
+			2
 		);
 
 		/**
 		 * Roll back to prior version if errors were detected post-update.
 		 */
 		WP_CLI::add_wp_hook(
-			'upgrade_verify_upgrader_process_complete', function( $site_response ) use ( $current_version, $is_site_response_errored ) {
+			'upgrade_verify_upgrader_process_complete',
+			function( $site_response ) use ( $current_version, $is_site_response_errored ) {
 				$is_errored = $is_site_response_errored( $site_response, 'post' );
 				if ( $is_errored ) {
 					if ( method_exists( 'WP_Upgrader', 'release_lock' ) ) {
@@ -132,7 +138,8 @@ class CLI {
 					}
 					WP_CLI::log( "Rolling WordPress back to version {$current_version}..." );
 					WP_CLI::runcommand(
-						'core download --skip-content --force --version=' . $current_version, array(
+						'core download --skip-content --force --version=' . $current_version,
+						array(
 							'launch' => false,
 						)
 					);
@@ -143,7 +150,8 @@ class CLI {
 
 		$update_version = ! empty( $assoc_args['version'] ) ? ' --version=' . $assoc_args['version'] : '';
 		$response       = WP_CLI::runcommand(
-			'core update' . $update_version, array(
+			'core update' . $update_version,
+			array(
 				'launch' => false,
 			)
 		);

--- a/src/Observer.php
+++ b/src/Observer.php
@@ -111,7 +111,8 @@ class Observer {
 			);
 		}
 		$response = wp_remote_post(
-			get_option( 'home' ), array(
+			get_option( 'home' ),
+			array(
 				'timeout' => 5,
 			)
 		);

--- a/wp-cli-load.php
+++ b/wp-cli-load.php
@@ -15,7 +15,8 @@ require_once dirname( __FILE__ ) . '/src/Observer.php';
 require_once dirname( __FILE__ ) . '/register-command.php';
 
 WP_CLI::add_wp_hook(
-	'plugins_loaded', function() {
+	'plugins_loaded',
+	function() {
 		require_once dirname( __FILE__ ) . '/update-verify.php';
 	}
 );


### PR DESCRIPTION
This should include the commands we're missing